### PR TITLE
Update version number

### DIFF
--- a/app/code/community/WirecardEE/PaymentGateway/etc/config.xml
+++ b/app/code/community/WirecardEE/PaymentGateway/etc/config.xml
@@ -9,7 +9,7 @@
 <config>
     <modules>
         <WirecardEE_PaymentGateway>
-            <version>1.2.1</version>
+            <version>1.2.2</version>
         </WirecardEE_PaymentGateway>
     </modules>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wirecard/magento-ee",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "scripts": {
     "test": "node_modules/.bin/mocha tests/Selenium/**/*Test.js --timeout 220000",
     "test:default": "node_modules/.bin/mocha tests/Selenium/Payments/DefaultTest.js --timeout 60000",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,6 +11,9 @@
 
 require_once __DIR__ . '/../../../app/Mage.php';
 
+//Define global ip address for tests
+$_SERVER['REMOTE_ADDR'] = '123.123.1.1';
+
 function fix_error_handler()
 {
     $mageErrorHandler = set_error_handler(function () {


### PR DESCRIPTION
With the release of a new plugin the newest paymentSDK(2.6.*) will be required which solves issues with the special characters in the descriptor.