### PR TITLE
Update used sdk version to 3.7.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=5.6",
-    "wirecard/payment-sdk-php": "3.6.*",
+    "wirecard/payment-sdk-php": "3.7.*",
     "php-http/guzzle5-adapter": "^1.0.1",
     "guzzlehttp/psr7": "^1.4",
     "ext-json": "*"


### PR DESCRIPTION
#43 Update the used sdk version to 3.7.*
With the 3.7.2 release of the SDK the php version requirements will be valid again.