### PR TITLE
make module installable via composer

### DIFF
--- a/app/code/community/WirecardEE/PaymentGateway/Block/Info.php
+++ b/app/code/community/WirecardEE/PaymentGateway/Block/Info.php
@@ -21,7 +21,7 @@ class WirecardEE_PaymentGateway_Block_Info extends Mage_Payment_Block_Info
     {
         parent::_construct();
 
-        if ($this->getAction()->getFullActionName() !== 'adminhtml_sales_order_view') {
+        if ($this->getAction() != null && $this->getAction()->getFullActionName() !== 'adminhtml_sales_order_view') {
             $this->setTemplate('WirecardEE/info.phtml');
         }
     }

--- a/app/code/community/WirecardEE/PaymentGateway/etc/config.xml
+++ b/app/code/community/WirecardEE/PaymentGateway/etc/config.xml
@@ -47,26 +47,6 @@
         </models>
 
         <events>
-            <wirecardee_paymentgateway_autoload>
-                <observers>
-                    <wirecard_ee_composer_autoload>
-                        <type>singleton</type>
-                        <class>paymentgateway/observer</class>
-                        <method>controllerFrontInitBefore</method>
-                    </wirecard_ee_composer_autoload>
-                </observers>
-            </wirecardee_paymentgateway_autoload>
-
-            <controller_front_init_before>
-                <observers>
-                    <wirecard_ee_composer_autoload>
-                        <type>singleton</type>
-                        <class>paymentgateway/observer</class>
-                        <method>controllerFrontInitBefore</method>
-                    </wirecard_ee_composer_autoload>
-                </observers>
-            </controller_front_init_before>
-
             <sales_order_payment_cancel>
                 <observers>
                     <wirecard_ee_cancel>

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "squizlabs/php_codesniffer": "^2.7",
     "codacy/coverage": "1.4.2"
   },
-  "type": "magento-extension",
+  "type": "magento-module",
   "scripts": {
     "upload-coverage": "codacycoverage clover build/coverage.xml",
     "cs-check": "phpcs --standard=phpcs.xml -s",


### PR DESCRIPTION
I did some changes to avoid the strange autoload mechanism of this module against all other modules. Now it is installable via composer and composer is responsible for the autoloading of classes. This avoids many errors we got with WirecardEE_PaymentGateway_Block_Info on line 24, (this->getAction is null when cron will send the mails)